### PR TITLE
Adds support for the FIXED_LINE_OR_MOBILE phone number type.

### DIFF
--- a/ext/gphone/gphone.cc
+++ b/ext/gphone/gphone.cc
@@ -165,6 +165,8 @@ namespace {
         return "fixed line";
       case PhoneNumberUtil::MOBILE:
         return "mobile";
+      case PhoneNumberUtil::FIXED_LINE_OR_MOBILE:
+        return "fixed line or mobile";
       case PhoneNumberUtil::TOLL_FREE:
         return "toll free";
       case PhoneNumberUtil::PREMIUM_RATE:

--- a/spec/gphone_spec.rb
+++ b/spec/gphone_spec.rb
@@ -113,7 +113,7 @@ describe "GPhone.new('+12069735100') (i.e. a fully qualified number)" do
   its(:area_code) { should == '206' }
   its(:subscriber_number) { should == '9735100' }
   its(:national_prefix) { should == '1' }
-  its(:type) { should == "unknown" }
+  its(:type) { should == "fixed line or mobile" }
 end
 
 describe "GPhone.new('12345234') (ie. with an invalid number)" do


### PR DESCRIPTION
Some countries, such as the United States, cannot distinguish between
land line and mobile numbers. The native libphonenumber provides a
`FIXED_LINE_OR_MOBILE` type to indicate this possibility. The library did
not previously expose this type, making such numbers "unknown".
